### PR TITLE
Allow character to appear more than once

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -32,7 +32,12 @@ $ozh_random_keyword['length'] = 5;
 yourls_add_filter( 'random_keyword', 'ozh_random_keyword' );
 function ozh_random_keyword() {
         global $ozh_random_keyword;
-        return yourls_rnd_string( $ozh_random_keyword['length'] );
+        $possible = yourls_get_shorturl_charset() ;
+        $str='';
+        while (strlen($str) < $ozh_random_keyword['length']) {
+                $str .= substr($possible, rand(0,strlen($possible)),1);
+        }
+        return $str;
 }
 
 // Don't increment sequential keyword tracker


### PR DESCRIPTION
Using str_shuffle means that each character can only occur once in the generated string. This reduces the number of permutations possible. For example, using base 36, and 4 characters, there are 36^4 = 1.68M, but the current function can only generate 36x35x34x33 = 1.41M of these. This alternative will use the whole range of possible strings.
