### PR TITLE
Fix getting random character from charset

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -35,7 +35,7 @@ function ozh_random_keyword() {
         $possible = yourls_get_shorturl_charset() ;
         $str='';
         while (strlen($str) < $ozh_random_keyword['length']) {
-                $str .= substr($possible, rand(0,strlen($possible)),1);
+                $str .= substr($possible, rand(0,strlen($possible)-1),1);
         }
         return $str;
 }


### PR DESCRIPTION
If `strlen($possible)` is for example 36, `rand` could also return 36. But `substr` starts with position 0. So we have to subtract 1 from `strlen($possible)`.